### PR TITLE
No update element with property

### DIFF
--- a/lib/components/chart.js
+++ b/lib/components/chart.js
@@ -107,7 +107,7 @@ Ember.C3.ChartComponent = Ember.Component.extend({
             // Editor is already created and cached.
             return self.get('_chart');
         }
-    }.property('element', '_config'),
+    }.property('_config'),
 
     /**
 
@@ -134,8 +134,7 @@ Ember.C3.ChartComponent = Ember.Component.extend({
         ]);
         c.bindto = self.get('element');
         return c;
-    }.property('element',
-        'data',
+    }.property('data',
         'axis',
         'regions',
         'bar',


### PR DESCRIPTION
Avoid check `element` and set it to avoid raising exception : 

```
Uncaught Error: Assertion Failed: You must use Ember.set() to set the `element` property (of <Ember.C3.ChartComponent:ember570>) to `null`.
```