### PR TITLE
Add gauge to README as an attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ See http://c3js.org/examples.html for examples of how to use C3.
   bar=bar
   pie=pie
   donut=donut
+  gauge=gauge
   grid=grid
   legend=legend
   tooltip=tooltip


### PR DESCRIPTION
I was trying to find it here, but didn't see it so wasn't sure how to set it, if it might have been an overloaded donut.