### PR TITLE
add debouncer to prevent excessive chart rendering

### DIFF
--- a/addon/components/c3-chart.js
+++ b/addon/components/c3-chart.js
@@ -190,7 +190,7 @@ export default Ember.Component.extend({
   /**
     Data Observer
   */
-  dataDidChange: Ember.observer('data', function() {
+  dataDidChange() {
     // console.log('data');
     var self = this;
     var chart = self.get('chart');
@@ -204,6 +204,11 @@ export default Ember.Component.extend({
     // console.log('data', data, chart);
     chart.load(data);
   }),
+  // prevent excessive chart re-rendering
+  debouncer: function() {
+    run.debounce(this, this.dataDidChange, 150);
+  }.observes('data'),
+  
   /**
   See https://github.com/emberjs/ember.js/issues/10661
   and http://stackoverflow.com/a/25523850/2578205


### PR DESCRIPTION
If data is based on an async computed property that updates frequently, c3 charts may render incorrectly. debounce solves this issue.