### PR TITLE
Added reuse option, to ensure that chart gets regenerated

### DIFF
--- a/addon/components/c3-chart.js
+++ b/addon/components/c3-chart.js
@@ -116,6 +116,7 @@ export default Ember.Component.extend({
         return undefined;
       } else {
         var config = self.get('_config');
+        self._cleanup();
         var chart = c3.generate(config);
         self.set('_chart', chart);
         return chart;
@@ -231,6 +232,21 @@ export default Ember.Component.extend({
       controller.addObserver(propertyKey, this, this.dataDidChange);
     }
     this.dataDidChange();
+    
+    this._super(...arguments);
+  },
+
+  willDestroyElement() {
+    this._cleanup();
+    this._super(...arguments);
+  },
+
+  _cleanup() {
+    var chart = this.get('_chart');
+    if (chart) {
+      chart.destroy();
+      this.set('_chart', null);
+    }
   }
 
 });

--- a/addon/components/c3-chart.js
+++ b/addon/components/c3-chart.js
@@ -106,10 +106,10 @@ export default Ember.Component.extend({
   /**
     The Chart
   */
-  chart: Ember.computed('config', function() {
+  chart: Ember.computed('_config', function() {
     var self = this;
-
-    if (Ember.isEmpty(self.get('_chart'))) {
+    var reuse = this.get('reuse');
+    if (!reuse || Ember.isEmpty(self.get('_chart'))) {
       // Empty, create it.
       var container = self.$().get(0);
       if (Ember.isEmpty(container)) {
@@ -127,6 +127,7 @@ export default Ember.Component.extend({
   }),
 
   _config: Ember.computed(
+  'reuse',
   'data',
   'axis',
   'regions',


### PR DESCRIPTION
Now it's possible to add an `reuse` option like this:

```
{{c3-chart  reuse=false data=model}}
```

This ensures that the chart gets regenerated, when using the same instance for multiple (different) charts. Otherwise changing data resolves in loading additional data into the existing chart, either then generating a new one. By setting `reuse=false`, this behavior gets disabled.
