### PR TITLE
fix d3 version to 3.5.17 in blueprint

### DIFF
--- a/blueprints/ember-c3/index.js
+++ b/blueprints/ember-c3/index.js
@@ -4,7 +4,9 @@ module.exports = {
   afterInstall: function() {
     var self = this;
 
-    return this.addBowerPackageToProject('d3').then(function(){
+    return this.addBowerPackagesToProject([
+      { name: 'd3', target: '3.5.17' }
+    ]).then(function(){
       return self.addBowerPackageToProject('c3');
     });
   }


### PR DESCRIPTION
because ``d3 >= 4.0.0`` breaks c3. 

D3 is now added with its latest 3.5 release.