### PR TITLE
Failed installation 

### DIFF
--- a/blueprints/ember-c3/index.js
+++ b/blueprints/ember-c3/index.js
@@ -4,12 +4,12 @@ module.exports = {
   afterInstall: function() {
     var self = this;
 
-    return this.addBowerPackageToProject([{
-        name: 'd3', target: '3.5.17'
-    }]).then(function(){
-      return self.addBowerPackageToProject('c3').then(function(){
-        return self.addAddonToProject('ember-c3-shim@0.0.6');
+    return this.addBowerPackageToProject('d3', '3.5.17')
+      .then(function() {
+        return self.addBowerPackageToProject('c3')
+          .then(function() {
+            self.addAddonToProject('ember-c3-shim@0.0.6');
+          });
       });
-    });
   }
 };


### PR DESCRIPTION
Hello,

When I execute the command 'ember install ember-c3' I get the following error and the installation fails.

> Installed packages for tooling via npm.
> installing ember-c3
> str.trim is not a function
> TypeError: str.trim is not a function

