### PR TITLE
Use dev-enabled bower assets in development and test envs

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,8 +6,20 @@ module.exports = {
   included: function(app) {
     this._super.included(app);
 
-    app.import(app.bowerDirectory + '/d3/d3.min.js');
-    app.import(app.bowerDirectory + '/c3/c3.min.css');
-    app.import(app.bowerDirectory + '/c3/c3.min.js');
+    app.import({
+      production: app.bowerDirectory + '/d3/d3.min.js',
+      development: app.bowerDirectory + '/d3/d3.js',
+      test: app.bowerDirectory + '/d3/d3.js'
+    });
+    app.import({
+      production: app.bowerDirectory + '/c3/c3.min.css',
+      development: app.bowerDirectory + '/c3/c3.css',
+      test: app.bowerDirectory + '/c3/c3.css'
+    });
+    app.import({
+      production: app.bowerDirectory + '/c3/c3.min.js',
+      development: app.bowerDirectory + '/c3/c3.js',
+      test: app.bowerDirectory + '/c3/c3.js'
+    });
   }
 };


### PR DESCRIPTION
The addon leaves very little space for d3 debugging by including `.min` assets in dev and test builds. This PR helps to make sure we have easily debuggable d3/c3 assets in test/dev environment but still would include `min` assets in production builds.