### PR TITLE
Fix reload

### DIFF
--- a/addon/components/c3-chart.js
+++ b/addon/components/c3-chart.js
@@ -75,7 +75,7 @@ export default Component.extend({
    * Component lifecycle hooks to control rendering actions
    ***/
 
-  didReceiveAttrs() {
+  didInsertElement() {
     // if DOM is not ready when component is inserted,
     // rendering issues can occur
     // t/f use 'afterRender' property to ensure


### PR DESCRIPTION
This should fix reloading when attributes have changed. The didReceiveAttrs hook is always called after didUpdateAttrs, which caused _setupc3() to be called again after attributes have been changed.