### PR TITLE
Prevent reload when component is being destroyed

### DIFF
--- a/addon/components/c3-chart.js
+++ b/addon/components/c3-chart.js
@@ -11,6 +11,10 @@ export default Component.extend({
 
   // triggered when data is updated by didUpdateAttrs
   _reload() {
+    // didUpdateAttrs() can schedule _reload when the component is being destroyed
+    // this prevents the reload and an error being spit out into the console
+    if (get(this, 'isDestroying') || get(this, 'isDestroyed')) { return }
+
     const chart = get(this, 'c3chart');
 
     // if data should not be appended


### PR DESCRIPTION
When transitioning to another route, the didUpdateAttrs() hook is called first for computed data which debounce schedules the _reload() hook which is then called after the component is destroyed thus spitting an error to the console.