### PR TITLE
Monorepo Support: Use require.resolve to find c3 path

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ module.exports = {
       trees.push(vendorTree);
 
     let cssTree = new Funnel(
-      path.join(this.project.root, "node_modules", "c3"),
+      path.resolve(require.resolve('c3'), '..'),
       {
         files: ["c3.css"]
       }


### PR DESCRIPTION
This is to support monorepo setups, where the `node_modules` directory might not be at the same level as the project root